### PR TITLE
 Swarm defined in config_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,9 @@ else (${crazyflie_cpp_FOUND})
   include(FetchContent)
   FetchContent_Declare(
   crazyflie_cpp
-  GIT_REPOSITORY https://github.com/whoenig/crazyflie_cpp.git
-  GIT_TAG 8b8391bc8e1899b4704723d22b5e4fa43ddef763
+  GIT_REPOSITORY https://github.com/miferco97/crazyflie_cpp.git
+  # GIT_TAG 8b8391bc8e1899b4704723d22b5e4fa43ddef763
+  GIT_TAG master
   )
   FetchContent_MakeAvailable(crazyflie_cpp)
 endif(${crazyflie_cpp_FOUND})
@@ -77,6 +78,33 @@ target_link_libraries(${PROJECT_NAME}_node
 )
 endif()
 
+
+add_executable(${PROJECT_NAME}_swarm_node src/crazyflie_swarm_nodes.cpp src/crazyflie_platform.cpp)
+ament_target_dependencies(${PROJECT_NAME}_swarm_node 
+  rclcpp 
+  sensor_msgs 
+  std_msgs
+  std_srvs
+  nav_msgs
+  as2_core
+  as2_msgs
+  geometry_msgs
+  Eigen3
+)
+
+if (${USE_CRAZYFLIE_COMPLETE_LIB})
+  # message("Yes!! COMPLETE")
+  target_link_libraries(${PROJECT_NAME}_swarm_node 
+    crazyflie_cpp::crazyflie_cpp
+  )
+else (${USE_CRAZYFLIE_COMPLETE_LIB})
+target_link_libraries(${PROJECT_NAME}_swarm_node 
+  crazyflie_cpp
+)
+endif()
+
+
+
 if(BUILD_TESTING)
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_clang_format REQUIRED)
@@ -98,6 +126,7 @@ install(DIRECTORY
 
 install(TARGETS
 ${PROJECT_NAME}_node
+${PROJECT_NAME}_swarm_node
   DESTINATION lib/${PROJECT_NAME})
 
 

--- a/config/crazy_swarm.yaml
+++ b/config/crazy_swarm.yaml
@@ -1,0 +1,10 @@
+# cf0:
+#   uri: radio://0/80/2M/E7E7E7E700
+# cf1:
+#   uri: radio://0/80/2M/E7E7E7E701
+# cf2:
+#   uri: radio://0/80/2M/E7E7E7E702
+cf3:
+  uri: radio://0/80/2M/E7E7E7E703
+cf4:
+  uri: radio://0/80/2M/E7E7E7E704

--- a/include/crazyflie_platform/crazyflie_platform.hpp
+++ b/include/crazyflie_platform/crazyflie_platform.hpp
@@ -61,16 +61,21 @@ struct logBattery {
 
 class CrazyfliePlatform : public as2::AerialPlatform {
 public:
+  void init();
   CrazyfliePlatform();
+  CrazyfliePlatform(const std::string &ns, const std::string &radio_uri);
+  void configureParams(const std::string &radio_uri = "");
 
   /*  --  AS2 FUNCTIONS --  */
 
-  void configureSensors();
+  void configureSensors() override;
 
-  bool ownSetArmingState(bool state);
-  bool ownSetOffboardControl(bool offboard);
-  bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &msg);
-  bool ownSendCommand();
+  bool ownSetArmingState(bool state) override;
+  bool ownSetOffboardControl(bool offboard) override;
+  bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode &msg) override;
+  bool ownSendCommand() override;
+  void ownKillSwitch() override { cf_->emergencyStop(); }
+  void ownStopPlatform() override { cf_->sendStop(); };
 
   /*  --  CRAZYFLIE FUNCTIONS --  */
 
@@ -79,7 +84,7 @@ public:
   void onLogIMU(uint32_t time_in_ms, std::vector<double> *values, void * /*userData*/);
   void onLogOdomOri(uint32_t time_in_ms, std::vector<double> *values, void * /*userData*/);
   void onLogOdomPos(uint32_t time_in_ms, std::vector<double> *values, void * /*userData*/);
-  void onLogBattery(uint32_t /*time_in_ms*/, struct logBattery *data);
+  void onLogBattery();
   void updateOdom();
   void externalOdomCB(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
 
@@ -90,13 +95,14 @@ public:
 private:
   std::shared_ptr<Crazyflie> cf_;
   rclcpp::TimerBase::SharedPtr ping_timer_;
+  rclcpp::TimerBase::SharedPtr bat_timer_;
   bool is_connected_;
   bool is_armed_;
   std::string uri_;
   uint8_t controller_type_;
   uint8_t estimator_type_;
 
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr stop_sub_;
+  // rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr stop_sub_;
 
   /*  --  SENSORS --  */
 
@@ -124,8 +130,8 @@ private:
   std::unique_ptr<as2::sensors::Sensor<sensor_msgs::msg::BatteryState>> battery_sensor_ptr_;
   unsigned char battery_buff_;
 
-  std::unique_ptr<LogBlock<struct logBattery>> bat_logBlock_;
-  std::function<void(uint32_t, struct logBattery *)> cb_bat_;
+  /* std::unique_ptr<LogBlock<struct logBattery>> bat_logBlock_;
+  std::function<void(uint32_t, struct logBattery *)> cb_bat_; */
 
   // Optitrack
   bool external_odom_;

--- a/launch/crazyflie_swarm_launch.py
+++ b/launch/crazyflie_swarm_launch.py
@@ -1,0 +1,64 @@
+from os.path import join
+
+import launch
+from launch import LaunchDescription, conditions
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, EnvironmentVariable
+from ament_index_python.packages import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+    config = join(
+        get_package_share_directory('crazyflie_platform'),
+        'config',
+        'control_modes.yaml'
+    )
+    swarm_config = join(
+        get_package_share_directory('crazyflie_platform'),
+        'config',
+        'crazy_swarm.yaml'
+    )
+    # DRONE_ID = os.environ['AEROSTACK2_SIMULATION_DRONE_ID']
+    return LaunchDescription([
+        # DeclareLaunchArgument('drone_id', default_value=DRONE_ID, description='Drone namespace.'),
+        DeclareLaunchArgument('mass', default_value='0.029'),
+        DeclareLaunchArgument('max_thrust', default_value='0.0'),
+        DeclareLaunchArgument('min_thrust', default_value='0.0'),
+        DeclareLaunchArgument('control_modes_file', default_value=config),
+        DeclareLaunchArgument('swarm_config_file', default_value=swarm_config),
+        DeclareLaunchArgument('drone_URI', default_value='radio://0/80/2M/E7E7E7E7E7', description='Crazyflie URI.'),
+        DeclareLaunchArgument('external_odom', default_value='false', choices=["true", "false"], description='Availability of external odometry.'),
+        DeclareLaunchArgument('external_odom_topic', default_value='external_odom', description='External odometry topic name.'),
+        DeclareLaunchArgument('simulation_mode', default_value='false', choices=["true", "false"], description="Simulation flag."),
+        DeclareLaunchArgument('controller_type', default_value='1', choices=["0", "1", "2", "3"], description="Controller type Any(0), PID(1), Mellinger(2), INDI(3) (Default: 0)."),
+        DeclareLaunchArgument('estimator_type', default_value='1', choices=["0", "1", "2"], description="Estimator type Any(0), complementary(1), kalman(2) (Default: 0)."),
+        DeclareLaunchArgument('ip', default_value="192.168.43.95"),
+        DeclareLaunchArgument('port', default_value='5000'),
+        DeclareLaunchArgument('save_flag', default_value='False'),
+        DeclareLaunchArgument('show_flag', default_value='False'),
+        # if is not in simulation
+        Node(
+            package="crazyflie_platform",
+            executable="crazyflie_platform_swarm_node",
+            name="platform",
+            # namespace=LaunchConfiguration('drone_id'),
+            output="screen",
+            emulate_tty=True,
+            parameters=[
+                {"mass": LaunchConfiguration('mass'),
+                "max_thrust": LaunchConfiguration('max_thrust'),
+                "control_modes_file": LaunchConfiguration('control_modes_file'),
+                "swarm_config_file": LaunchConfiguration('swarm_config_file'),
+                "external_odom" : LaunchConfiguration('external_odom'),
+                "drone_URI" : LaunchConfiguration('drone_URI'),
+                "external_odom_topic" : LaunchConfiguration('external_odom_topic'),
+                "min_thrust": LaunchConfiguration('min_thrust'),
+                "simulation_mode": LaunchConfiguration('simulation_mode'),
+                "controller_type": LaunchConfiguration('controller_type'),
+                "estimator_type": LaunchConfiguration('estimator_type'),
+                }],
+            #remappings=[("sensor_measurements/odometry", "self_localization/odom")],
+        )
+    ])

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <name>crazyflie_platform</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
-  <maintainer email="miguelgranero99@gmail.com">miguel</maintainer>
+  <maintainer email="cvar.upm3@gmail.com">cvar</maintainer>
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/src/crazyflie_swarm_nodes.cpp
+++ b/src/crazyflie_swarm_nodes.cpp
@@ -1,0 +1,138 @@
+/*!*******************************************************************************************
+ *  \file       crazyflie_swarm_launch.cpp
+ *  \brief      Runs the crazyflie_platform swarm.
+ *  \authors    Miguel Fernández Cortizas
+ *
+ *  \copyright  Copyright (c) 2022 Universidad Politécnica de Madrid
+ *              All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ********************************************************************************/
+#include <as2_core/utils/yaml_utils.hpp>
+#include <iostream>
+#include <rclcpp/parameter_map.hpp>
+#include <rclcpp/utilities.hpp>
+#include "as2_core/core_functions.hpp"
+#include "as2_core/node.hpp"
+#include "crazyflie_platform.hpp"
+
+#define SWARM_ARG_NAME "swarm_config_file"
+#define PARAMS_ARG_NAME "params-file"
+#define URI_ARG_NAME "uri"
+#define MEDIUM_FREQ_NODE 75
+
+std::string find_argument_value(const std::string& argument, int argc, char** argv) {
+  std::string res = "";
+  std::string arg = "--" + argument;
+  for (int i = 0; i < argc; i++) {
+    if (arg == argv[i]) {
+      if (i + 1 < argc) {
+        res = argv[i + 1];
+      }
+    }
+  }
+  return res;
+}
+
+YAML::Node traverse_map(const YAML::Node& node, const std::string& key) {
+  YAML::Node res;
+  if (node[key]) {
+    res = node[key];
+  } else {
+    for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
+      if (it->second.IsMap()) {
+        res = traverse_map(it->second, key);
+        if (res) {
+          break;
+        }
+      }
+    }
+  }
+  return res;
+}
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  std::vector<rclcpp::Node::SharedPtr> nodes;
+  std::string swarm_config_file = find_argument_value(SWARM_ARG_NAME, argc, argv);
+  if (swarm_config_file.empty()) {
+    std::string params_file = find_argument_value(PARAMS_ARG_NAME, argc, argv);
+    try {
+      YAML::Node params     = YAML::LoadFile(params_file);
+      YAML::Node swarm_path = traverse_map(params, SWARM_ARG_NAME);
+      if (swarm_path) {
+        swarm_config_file = swarm_path.as<std::string>();
+      }
+
+    } catch (std::exception& e) {
+      std::cout << "Error reading file: " << e.what() << std::endl;
+      return 1;
+    }
+  }
+  if (swarm_config_file.empty()) {
+    std::cout
+        << "Swarm config file not found. Please provide it as an argument or in the params file."
+        << std::endl;
+    return 1;
+  }
+  std::cout << "Swarm config file: " << swarm_config_file << std::endl;
+
+  YAML::Node swarm_config = YAML::LoadFile(swarm_config_file);
+  for (YAML::const_iterator it = swarm_config.begin(); it != swarm_config.end(); ++it) {
+    std::string name       = it->first.as<std::string>();
+    YAML::Node node_config = it->second;
+    if (node_config.IsMap()) {
+      for (YAML::const_iterator it2 = node_config.begin(); it2 != node_config.end(); ++it2) {
+        std::string key = it2->first.as<std::string>();
+        if (key == URI_ARG_NAME) {
+          std::string value = it2->second.as<std::string>();
+          std::cout << "Creating node " << name << " with uri " << value << std::endl;
+          nodes.emplace_back(std::make_shared<CrazyfliePlatform>(name, value));
+        }
+      }
+    }
+  }
+
+  /* auto cf_0 = std::make_shared<CrazyfliePlatform>("cf0", "radio://0/80/2M/E7E7E7E700");
+  auto cf_1 = std::make_shared<CrazyfliePlatform>("cf1", "radio://0/80/2M/E7E7E7E701");
+  auto cf_2 = std::make_shared<CrazyfliePlatform>("cf2", "radio://0/80/2M/E7E7E7E702"); */
+  if (nodes.empty()) {
+    std::cout << "No nodes created. Exiting." << std::endl;
+    return 1;
+  }
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  rclcpp::Rate r(int(MEDIUM_FREQ_NODE * nodes.size()));
+  while (rclcpp::ok()) {
+    for (auto& node : nodes) {
+      executor.spin_node_some(node);
+      r.sleep();
+    }
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Now Crazyflie_platform use crazyflie_link_cpp to connect the MAVs, which enhances connection robustness and now this platform supports handling multiple crazyflies with one antenna in the same process, via crazyflie_swarm_launch.py and a crazy_swarm.yaml file.